### PR TITLE
Recursively remove sub fcs when being removed

### DIFF
--- a/Sources/Code/FlowController.swift
+++ b/Sources/Code/FlowController.swift
@@ -24,17 +24,18 @@ open class FlowController: NSObject {
     /// - Parameters:
     ///   - subFlowController: The sub flow controller to be added.
     public func add(subFlowController: FlowController) {
-        // clean up
+        // Clean up
         self.subFlowController?.removeFromSuperFlowController()
         subFlowController.removeFromSuperFlowController()
 
-        // store new
+        // Store new
         self.subFlowController = subFlowController
         subFlowController.superFlowController = self
     }
 
     /// Removes this flow controller from its super flow controller.
     public func removeFromSuperFlowController() {
+        subFlowController?.removeFromSuperFlowController()
         superFlowController?.subFlowController = nil
         superFlowController = nil
     }


### PR DESCRIPTION
Closes #6. Actually doesn't remove the hint to use `[unowned self]` from the documentation, but fixes a potential leak when not using it.